### PR TITLE
Increase the size of the hash array to accommodate higher dhandle counts

### DIFF
--- a/src/third_party/wiredtiger/src/include/misc.h
+++ b/src/third_party/wiredtiger/src/include/misc.h
@@ -85,7 +85,7 @@
  * Default hash table size; we don't need a prime number of buckets
  * because we always use a good hash function.
  */
-#define	WT_HASH_ARRAY_SIZE	512
+#define	WT_HASH_ARRAY_SIZE	131072
 
 /*
  * __wt_calloc_def, __wt_calloc_one --


### PR DESCRIPTION
Increase hash array size to 65536 from 512.

The size of the hash array is critical in performance of dhandle lookups. The default size is not large enough to accommodate shards with tens of thousands of dhandles. These lookups make up a significant portion of the time in preparing a checkpoint. While a checkpoint is being prepared, application request handling is slowed down dramatically. Increasing the hash array size will therefore mitigate the amount of time that app requests are blocked during checkpointing.