### PR TITLE
Add controls for cursor sweep min and max buckets

### DIFF
--- a/src/third_party/wiredtiger/dist/api_data.py
+++ b/src/third_party/wiredtiger/dist/api_data.py
@@ -907,6 +907,12 @@ wiredtiger_open_common =\
     Config('session_cursor_cache_size', '512', r'''
         size of hash array that holds cached session cursors''',
         min='512'),
+    Config('session_cursor_sweep_max', '32', r'''
+        maximum number of cursor cache hash table buckets to sweep''',
+        min='32'),
+    Config('session_cursor_sweep_min', '5', r'''
+        minimum number of cursor cache hash table buckets to sweep ''',
+        min='5'),
     Config('session_table_cache', 'true', r'''
         Maintain a per-session cache of tables''',
         type='boolean', undoc=True), # Obsolete after WT-3476

--- a/src/third_party/wiredtiger/dist/stat_data.py
+++ b/src/third_party/wiredtiger/dist/stat_data.py
@@ -471,8 +471,6 @@ connection_stats = [
     # Session operations
     ##########################################
     SessionStat('session_open', 'open session count', 'no_clear,no_scale'),
-    SessionStat('session_cursor_cache_size', 'session cursor cache size', 'no_clear,no_scale'),
-    SessionStat('session_dhhash_size', 'session dhandle hash size', 'no_clear,no_scale'),
     SessionStat('session_query_ts', 'session query timestamp calls'),
     SessionStat('session_table_alter_fail', 'table alter failed calls', 'no_clear,no_scale'),
     SessionStat('session_table_alter_skip', 'table alter unchanged and skipped', 'no_clear,no_scale'),

--- a/src/third_party/wiredtiger/src/config/config_def.c
+++ b/src/third_party/wiredtiger/src/config/config_def.c
@@ -883,6 +883,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 	{ "session_cursor_cache_size", "int",
 	    NULL, "min=512",
 	    NULL, 0 },
+	{ "session_cursor_sweep_max", "int", NULL, "min=32", NULL, 0 },
+	{ "session_cursor_sweep_min", "int", NULL, "min=5", NULL, 0 },
 	{ "session_dhhash_size", "int", NULL, "min=512", NULL, 0 },
 	{ "session_max", "int", NULL, "min=1", NULL, 0 },
 	{ "session_scratch_max", "int", NULL, NULL, NULL, 0 },
@@ -993,6 +995,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 	{ "session_cursor_cache_size", "int",
 	    NULL, "min=512",
 	    NULL, 0 },
+	{ "session_cursor_sweep_max", "int", NULL, "min=32", NULL, 0 },
+	{ "session_cursor_sweep_min", "int", NULL, "min=5", NULL, 0 },
 	{ "session_dhhash_size", "int", NULL, "min=512", NULL, 0 },
 	{ "session_max", "int", NULL, "min=1", NULL, 0 },
 	{ "session_scratch_max", "int", NULL, NULL, NULL, 0 },
@@ -1100,6 +1104,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 	{ "session_cursor_cache_size", "int",
 	    NULL, "min=512",
 	    NULL, 0 },
+	{ "session_cursor_sweep_max", "int", NULL, "min=32", NULL, 0 },
+	{ "session_cursor_sweep_min", "int", NULL, "min=5", NULL, 0 },
 	{ "session_dhhash_size", "int", NULL, "min=512", NULL, 0 },
 	{ "session_max", "int", NULL, "min=1", NULL, 0 },
 	{ "session_scratch_max", "int", NULL, NULL, NULL, 0 },
@@ -1205,6 +1211,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 	{ "session_cursor_cache_size", "int",
 	    NULL, "min=512",
 	    NULL, 0 },
+	{ "session_cursor_sweep_max", "int", NULL, "min=32", NULL, 0 },
+	{ "session_cursor_sweep_min", "int", NULL, "min=5", NULL, 0 },
 	{ "session_dhhash_size", "int", NULL, "min=512", NULL, 0 },
 	{ "session_max", "int", NULL, "min=1", NULL, 0 },
 	{ "session_scratch_max", "int", NULL, NULL, NULL, 0 },
@@ -1557,6 +1565,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "lsm_merge=true,mmap=true,multiprocess=false,"
 	  "operation_tracking=(enabled=false,path=\".\"),readonly=false,"
 	  "salvage=false,session_cursor_cache_size=512,"
+	  "session_cursor_sweep_max=32,session_cursor_sweep_min=5,"
 	  "session_dhhash_size=8192,session_max=100,session_scratch_max=2MB"
 	  ",session_table_cache=true,shared_cache=(chunk=10MB,name=,quota=0"
 	  ",reserve=0,size=500MB),statistics=none,"
@@ -1565,7 +1574,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "transaction_sync=(enabled=false,method=fsync),"
 	  "use_environment=true,use_environment_priv=false,verbose=,"
 	  "write_through=",
-	  confchk_wiredtiger_open, 49
+	  confchk_wiredtiger_open, 51
 	},
 	{ "wiredtiger_open_all",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
@@ -1586,6 +1595,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "lsm_merge=true,mmap=true,multiprocess=false,"
 	  "operation_tracking=(enabled=false,path=\".\"),readonly=false,"
 	  "salvage=false,session_cursor_cache_size=512,"
+	  "session_cursor_sweep_max=32,session_cursor_sweep_min=5,"
 	  "session_dhhash_size=8192,session_max=100,session_scratch_max=2MB"
 	  ",session_table_cache=true,shared_cache=(chunk=10MB,name=,quota=0"
 	  ",reserve=0,size=500MB),statistics=none,"
@@ -1594,7 +1604,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "transaction_sync=(enabled=false,method=fsync),"
 	  "use_environment=true,use_environment_priv=false,verbose=,"
 	  "version=(major=0,minor=0),write_through=",
-	  confchk_wiredtiger_open_all, 50
+	  confchk_wiredtiger_open_all, 52
 	},
 	{ "wiredtiger_open_basecfg",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
@@ -1613,14 +1623,15 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
 	  "mmap=true,multiprocess=false,operation_tracking=(enabled=false,"
 	  "path=\".\"),readonly=false,salvage=false,"
-	  "session_cursor_cache_size=512,session_dhhash_size=8192,"
+	  "session_cursor_cache_size=512,session_cursor_sweep_max=32,"
+	  "session_cursor_sweep_min=5,session_dhhash_size=8192,"
 	  "session_max=100,session_scratch_max=2MB,session_table_cache=true"
 	  ",shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
 	  "statistics=none,statistics_log=(json=false,on_close=false,"
 	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
 	  "method=fsync),verbose=,version=(major=0,minor=0),write_through=",
-	  confchk_wiredtiger_open_basecfg, 44
+	  confchk_wiredtiger_open_basecfg, 46
 	},
 	{ "wiredtiger_open_usercfg",
 	  "async=(enabled=false,ops_max=1024,threads=2),buffer_alignment=-1"
@@ -1639,14 +1650,15 @@ static const WT_CONFIG_ENTRY config_entries[] = {
 	  "lsm_manager=(merge=true,worker_thread_max=4),lsm_merge=true,"
 	  "mmap=true,multiprocess=false,operation_tracking=(enabled=false,"
 	  "path=\".\"),readonly=false,salvage=false,"
-	  "session_cursor_cache_size=512,session_dhhash_size=8192,"
+	  "session_cursor_cache_size=512,session_cursor_sweep_max=32,"
+	  "session_cursor_sweep_min=5,session_dhhash_size=8192,"
 	  "session_max=100,session_scratch_max=2MB,session_table_cache=true"
 	  ",shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
 	  "statistics=none,statistics_log=(json=false,on_close=false,"
 	  "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
 	  "timing_stress_for_test=,transaction_sync=(enabled=false,"
 	  "method=fsync),verbose=,write_through=",
-	  confchk_wiredtiger_open_usercfg, 43
+	  confchk_wiredtiger_open_usercfg, 45
 	},
 	{ NULL, NULL, NULL, 0 }
 };

--- a/src/third_party/wiredtiger/src/conn/conn_api.c
+++ b/src/third_party/wiredtiger/src/conn/conn_api.c
@@ -2593,6 +2593,14 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler,
 		session, cfg, "session_cursor_cache_size", &cval));
 	conn->session_cursor_cache_size = cval.val;
 
+	WT_ERR(__wt_config_gets(
+		session, cfg, "session_cursor_sweep_max", &cval));
+	conn->session_cursor_sweep_max = cval.val;
+
+	WT_ERR(__wt_config_gets(
+		session, cfg, "session_cursor_sweep_min", &cval));
+	conn->session_cursor_sweep_min = cval.val;
+
 	/*
 	 * If buffer alignment is not configured, use zero unless direct I/O is
 	 * also configured, in which case use the build-time default. The code

--- a/src/third_party/wiredtiger/src/include/connection.h
+++ b/src/third_party/wiredtiger/src/include/connection.h
@@ -248,6 +248,8 @@ struct __wt_connection_impl {
 
 	uint32_t session_dhhash_size;	/* Session dhandle hash array size */
 	uint32_t session_cursor_cache_size;	/* Session cursor cache size */
+	uint32_t session_cursor_sweep_max; /* Max cursor buckets to sweep */
+	uint32_t session_cursor_sweep_min; /* Min cursor buckets to sweep */
 
 	WT_CACHE  *cache;		/* Page cache */
 	volatile uint64_t cache_size;	/* Cache size (either statically

--- a/src/third_party/wiredtiger/src/include/session.h
+++ b/src/third_party/wiredtiger/src/include/session.h
@@ -42,11 +42,6 @@ typedef TAILQ_HEAD(__wt_cursor_list, __wt_cursor)	WT_CURSOR_LIST;
 /* Number of cursors cached to trigger cursor sweep. */
 #define	WT_SESSION_CURSOR_SWEEP_COUNTDOWN	20
 
-/* Minimum number of buckets to visit during cursor sweep. */
-#define	WT_SESSION_CURSOR_SWEEP_MIN		5
-
-/* Maximum number of buckets to visit during cursor sweep. */
-#define	WT_SESSION_CURSOR_SWEEP_MAX		32
 /*
  * WT_SESSION_IMPL --
  *	Implementation of WT_SESSION.

--- a/src/third_party/wiredtiger/src/include/stat.h
+++ b/src/third_party/wiredtiger/src/include/stat.h
@@ -592,8 +592,6 @@ struct __wt_connection_stats {
 	int64_t rec_split_stashed_bytes;
 	int64_t rec_split_stashed_objects;
 	int64_t session_open;
-	int64_t session_cursor_cache_size;
-	int64_t session_dhhash_size;
 	int64_t session_query_ts;
 	int64_t session_table_alter_fail;
 	int64_t session_table_alter_success;

--- a/src/third_party/wiredtiger/src/include/wiredtiger.in
+++ b/src/third_party/wiredtiger/src/include/wiredtiger.in
@@ -2990,6 +2990,10 @@ struct __wt_connection {
  * default \c false.}
  * @config{session_cursor_cache_size, size of hash array that holds cached
  * session cursors., an integer greater than or equal to 512; default \c 512.}
+ * @config{session_cursor_sweep_max, maximum number of cursor cache hash table
+ * buckets to sweep., an integer greater than or equal to 32; default \c 32.}
+ * @config{session_cursor_sweep_min, minimum number of cursor cache hash table
+ * buckets to sweep., an integer greater than or equal to 5; default \c 5.}
  * @config{session_dhhash_size, size of hash array that holds cached session
  * dhandles., an integer greater than or equal to 512; default \c 8192.}
  * @config{session_max, maximum expected number of sessions (including server
@@ -5583,231 +5587,227 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1277
 /*! session: open session count */
 #define	WT_STAT_CONN_SESSION_OPEN			1278
-/*! session: session cursor cache size */
-#define	WT_STAT_CONN_SESSION_CURSOR_CACHE_SIZE		1279
-/*! session: session dhandle hash size */
-#define	WT_STAT_CONN_SESSION_DHHASH_SIZE		1280
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1281
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1279
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1282
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1280
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1283
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1281
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1284
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1282
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1285
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1283
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1286
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1284
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1287
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1285
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1288
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1286
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1289
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1287
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1290
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1288
 /*! session: table rebalance failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1291
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_FAIL	1289
 /*! session: table rebalance successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1292
+#define	WT_STAT_CONN_SESSION_TABLE_REBALANCE_SUCCESS	1290
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1293
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1291
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1294
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1292
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1295
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1293
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1296
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1294
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1297
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1295
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1298
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1296
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1299
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1297
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1300
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1298
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1301
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1299
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1302
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1300
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1303
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1301
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1304
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1302
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1305
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1303
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1306
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1304
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1307
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1305
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1308
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1306
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1309
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1307
 /*! thread-yield: log server sync yielded for log write */
-#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1310
+#define	WT_STAT_CONN_LOG_SERVER_SYNC_BLOCKED		1308
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1311
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1309
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1312
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1310
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1313
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1311
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1314
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1312
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1315
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1313
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1316
+#define	WT_STAT_CONN_PAGE_SLEEP				1314
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1317
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1315
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1318
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1316
 /*! transaction: commit timestamp queue entries walked */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_WALKED		1319
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_WALKED		1317
 /*! transaction: commit timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1320
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_EMPTY		1318
 /*! transaction: commit timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_HEAD		1321
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_HEAD		1319
 /*! transaction: commit timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1322
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_INSERTS		1320
 /*! transaction: commit timestamp queue length */
-#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1323
+#define	WT_STAT_CONN_TXN_COMMIT_QUEUE_LEN		1321
 /*! transaction: number of named snapshots created */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1324
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_CREATED		1322
 /*! transaction: number of named snapshots dropped */
-#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1325
+#define	WT_STAT_CONN_TXN_SNAPSHOTS_DROPPED		1323
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1326
+#define	WT_STAT_CONN_TXN_PREPARE			1324
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1327
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1325
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1328
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1326
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1329
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1327
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1330
+#define	WT_STAT_CONN_TXN_QUERY_TS			1328
 /*! transaction: read timestamp queue entries walked */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_WALKED		1331
+#define	WT_STAT_CONN_TXN_READ_QUEUE_WALKED		1329
 /*! transaction: read timestamp queue insert to empty */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1332
+#define	WT_STAT_CONN_TXN_READ_QUEUE_EMPTY		1330
 /*! transaction: read timestamp queue inserts to head */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1333
+#define	WT_STAT_CONN_TXN_READ_QUEUE_HEAD		1331
 /*! transaction: read timestamp queue inserts total */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1334
+#define	WT_STAT_CONN_TXN_READ_QUEUE_INSERTS		1332
 /*! transaction: read timestamp queue length */
-#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1335
+#define	WT_STAT_CONN_TXN_READ_QUEUE_LEN			1333
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1336
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE		1334
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1337
+#define	WT_STAT_CONN_TXN_ROLLBACK_UPD_ABORTED		1335
 /*! transaction: rollback to stable updates removed from cache overflow */
-#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1338
+#define	WT_STAT_CONN_TXN_ROLLBACK_LAS_REMOVED		1336
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1339
+#define	WT_STAT_CONN_TXN_SET_TS				1337
 /*! transaction: set timestamp commit calls */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1340
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT			1338
 /*! transaction: set timestamp commit updates */
-#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1341
+#define	WT_STAT_CONN_TXN_SET_TS_COMMIT_UPD		1339
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1342
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1340
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1343
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1341
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1344
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1342
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1345
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1343
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1346
+#define	WT_STAT_CONN_TXN_BEGIN				1344
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1347
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1345
 /*! transaction: transaction checkpoint dhandle with ckpt */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_DHANDLE_WITH_CKPT	1348
+#define	WT_STAT_CONN_TXN_CHECKPOINT_DHANDLE_WITH_CKPT	1346
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1349
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1347
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1350
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1348
 /*! transaction: transaction checkpoint meta ckptlist parse */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_META_CKPTLIST_PARSE	1351
+#define	WT_STAT_CONN_TXN_CHECKPOINT_META_CKPTLIST_PARSE	1349
 /*! transaction: transaction checkpoint meta ckptlist search */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_META_CKPTLIST_SEARCH	1352
+#define	WT_STAT_CONN_TXN_CHECKPOINT_META_CKPTLIST_SEARCH	1350
 /*! transaction: transaction checkpoint meta ckptlist set */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_META_CKPTLIST_SET	1353
+#define	WT_STAT_CONN_TXN_CHECKPOINT_META_CKPTLIST_SET	1351
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1354
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1352
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1355
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1353
 /*! transaction: transaction checkpoint prepare time (usecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREPARE_TIME	1356
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREPARE_TIME	1354
 /*!
  * transaction: transaction checkpoint prepare with schema lock time
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREPARE_WITH_SCHEMA_LOCK_TIME	1357
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREPARE_WITH_SCHEMA_LOCK_TIME	1355
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1358
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1356
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1359
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1357
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1360
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1358
 /*! transaction: transaction checkpoint tree helper cache op time (usecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_CACHE_OP_TIME	1361
+#define	WT_STAT_CONN_TXN_CHECKPOINT_CACHE_OP_TIME	1359
 /*! transaction: transaction checkpoint tree helper time (usecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TREE_HELPER_TIME	1362
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TREE_HELPER_TIME	1360
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1363
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1361
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1364
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1362
 /*! transaction: transaction failures due to cache overflow */
-#define	WT_STAT_CONN_TXN_FAIL_CACHE			1365
+#define	WT_STAT_CONN_TXN_FAIL_CACHE			1363
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1366
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1364
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1367
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1365
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1368
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1366
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1369
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1367
 /*!
  * transaction: transaction range of IDs currently pinned by named
  * snapshots
  */
-#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1370
+#define	WT_STAT_CONN_TXN_PINNED_SNAPSHOT_RANGE		1368
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1371
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1369
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1372
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1370
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1373
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1371
 /*! transaction: transaction sync calls */
-#define	WT_STAT_CONN_TXN_SYNC				1374
+#define	WT_STAT_CONN_TXN_SYNC				1372
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1375
+#define	WT_STAT_CONN_TXN_COMMIT				1373
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1376
+#define	WT_STAT_CONN_TXN_ROLLBACK			1374
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1377
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1375
 
 /*!
  * @}

--- a/src/third_party/wiredtiger/src/session/session_api.c
+++ b/src/third_party/wiredtiger/src/session/session_api.c
@@ -82,7 +82,9 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
 
 	/* Turn off caching so that cursor close doesn't try to cache. */
 	F_CLR(session, WT_SESSION_CACHE_CURSORS);
-	for (i = 0; i < WT_SESSION_CURSOR_SWEEP_MAX && productive; i++) {
+	for (i = 0; i < (int)S2C(session)->session_cursor_sweep_max &&
+		productive; i++)
+	{
 		++nbuckets;
 		cached_list = &session->cursor_cache[position];
 		position = (position + 1) %
@@ -106,7 +108,8 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
 		 * We continue sweeping as long as we have some good average
 		 * productivity, or we are under the minimum.
 		 */
-		productive = (nclosed + WT_SESSION_CURSOR_SWEEP_MIN > i);
+		productive = (nclosed +
+			(int)S2C(session)->session_cursor_sweep_min > i);
 	}
 
 	session->cursor_sweep_position = position;
@@ -2193,16 +2196,10 @@ __open_session(WT_CONNECTION_IMPL *conn,
 		WT_ERR(__wt_calloc_def(
 		    session, conn->session_cursor_cache_size,
 			&session_ret->cursor_cache));
-
-		WT_STAT_CONN_SET(session, session_cursor_cache_size,
-			conn->session_cursor_cache_size);
 	}
 	if (session_ret->dhhash == NULL) {
 		WT_ERR(__wt_calloc_def(
 		    session, conn->session_dhhash_size, &session_ret->dhhash));
-
-		WT_STAT_CONN_SET(session,
-			session_dhhash_size, conn->session_dhhash_size);
 	}
 
 	/* Initialize the dhandle hash array. */

--- a/src/third_party/wiredtiger/src/support/stat.c
+++ b/src/third_party/wiredtiger/src/support/stat.c
@@ -1021,8 +1021,6 @@ static const char * const __stats_connection_desc[] = {
 	"reconciliation: split bytes currently awaiting free",
 	"reconciliation: split objects currently awaiting free",
 	"session: open session count",
-	"session: session cursor cache size",
-	"session: session dhandle hash size",
 	"session: session query timestamp calls",
 	"session: table alter failed calls",
 	"session: table alter successful calls",
@@ -1441,8 +1439,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
 		/* not clearing rec_split_stashed_bytes */
 		/* not clearing rec_split_stashed_objects */
 		/* not clearing session_open */
-		/* not clearing session_cursor_cache_size */
-		/* not clearing session_dhhash_size */
 	stats->session_query_ts = 0;
 		/* not clearing session_table_alter_fail */
 		/* not clearing session_table_alter_success */
@@ -1970,9 +1966,6 @@ __wt_stat_connection_aggregate(
 	to->rec_split_stashed_objects +=
 	    WT_STAT_READ(from, rec_split_stashed_objects);
 	to->session_open += WT_STAT_READ(from, session_open);
-	to->session_cursor_cache_size +=
-	    WT_STAT_READ(from, session_cursor_cache_size);
-	to->session_dhhash_size += WT_STAT_READ(from, session_dhhash_size);
 	to->session_query_ts += WT_STAT_READ(from, session_query_ts);
 	to->session_table_alter_fail +=
 	    WT_STAT_READ(from, session_table_alter_fail);


### PR DESCRIPTION
Add knobs to control the max and min buckets to visit during session cursor sweep.

This patch also removes the (unnecessary) stats showing the configured session dhandle and cursor cache hash sizes.